### PR TITLE
PJAS-2602 Fix PHP deprecation

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2007,11 +2007,11 @@ class S3
 			$combinedHeaders[strtolower($k)] = trim($v);
 		foreach ($amzHeaders as $k => $v) 
 			$combinedHeaders[strtolower($k)] = trim($v);
-		uksort($combinedHeaders, array('self', '__sortMetaHeadersCmp'));
+		uksort($combinedHeaders, array(self::class, '__sortMetaHeadersCmp'));
 
 		// Convert null query string parameters to strings and sort
 		$parameters = array_map('strval', $parameters); 
-		uksort($parameters, array('self', '__sortMetaHeadersCmp'));
+		uksort($parameters, array(self::class, '__sortMetaHeadersCmp'));
 		$queryString = http_build_query($parameters, "", '&', PHP_QUERY_RFC3986);
 
 		// Payload


### PR DESCRIPTION
Use of "self" in callables is deprecated in file /var/www/vendor/cineman/amazon-s3-php-class/S3.php.

Related PRs:
BN-Bot: https://github.com/prospective/bn-bot/pull/2