### PR TITLE
PJAS-2602 Fix php deprecations

### DIFF
--- a/S3.php
+++ b/S3.php
@@ -2007,11 +2007,11 @@ class S3
 			$combinedHeaders[strtolower($k)] = trim($v);
 		foreach ($amzHeaders as $k => $v) 
 			$combinedHeaders[strtolower($k)] = trim($v);
-		uksort($combinedHeaders, array('self', '__sortMetaHeadersCmp'));
+		uksort($combinedHeaders, array(self::class, '__sortMetaHeadersCmp'));
 
 		// Convert null query string parameters to strings and sort
 		$parameters = array_map('strval', $parameters); 
-		uksort($parameters, array('self', '__sortMetaHeadersCmp'));
+		uksort($parameters, array(self::class, '__sortMetaHeadersCmp'));
 		$queryString = http_build_query($parameters, null, '&', PHP_QUERY_RFC3986);
 
 		// Payload

--- a/S3.php
+++ b/S3.php
@@ -2511,7 +2511,7 @@ final class S3Request
 			elseif ($header == 'content-type')
 				$this->response->headers['type'] = $value;
 			elseif ($header == 'etag')
-				$this->response->headers['hash'] = $value{0} == '"' ? substr($value, 1, -1) : $value;
+				$this->response->headers['hash'] = $value[0] == '"' ? substr($value, 1, -1) : $value;
 			elseif (preg_match('/^x-amz-meta-.*$/', $header))
 				$this->response->headers[$header] = $value;
 		}


### PR DESCRIPTION
Use of "self" in callables is deprecated in file /var/www/vendor/cineman/amazon-s3-php-class/S3.php.

Related PRs:
BN-Bot: https://github.com/prospective/bn-bot/pull/2